### PR TITLE
Add Jest tests for formatCurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "test": "jest"
   },
   "dependencies": {
     "core-js": "^3.8.3",

--- a/tests/unit/money.spec.js
+++ b/tests/unit/money.spec.js
@@ -1,0 +1,15 @@
+const { formatCurrency } = require('../../src/utilities/money');
+
+describe('formatCurrency', () => {
+  test('formats positive amounts', () => {
+    expect(formatCurrency(1234.56)).toBe('$1,234.56');
+  });
+
+  test('formats negative amounts', () => {
+    expect(formatCurrency(-45.6)).toBe('-$45.60');
+  });
+
+  test('rounds to two decimals', () => {
+    expect(formatCurrency(1.005)).toBe('$1.01');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for money utils
- wire up `npm test` script with Jest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855c3eb3f288330bf2b1255bec4b113