### PR TITLE
Fix typo in expense row master comment

### DIFF
--- a/src/components/ExpenseUpload/ExpenseRowMaster.vue
+++ b/src/components/ExpenseUpload/ExpenseRowMaster.vue
@@ -140,7 +140,7 @@ export default {
       () => store.getters["categoryStore/organized"]
     );
 
-    //determine initial edit mdoe
+    //determine initial edit mode
     if (state.bank_entry.bank_entry_id === 0) {
       editMode.value = MODES.ADD;
     } else {


### PR DESCRIPTION
## Summary
- fix typo in comment for determining initial edit mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855c3e01e008330aadadd306de45764